### PR TITLE
Rename all Dtos except for ForgetPassword

### DIFF
--- a/Apps/PalatePilot.Server/Controllers/AuthController.cs
+++ b/Apps/PalatePilot.Server/Controllers/AuthController.cs
@@ -21,7 +21,7 @@ namespace PalatePilot.Server.Controllers
         // POST: api/Auth/Registration
         [HttpPost("Registration")]
         [ValidateModel]
-        public async Task<IActionResult> Registration(RegistrationRequestDto request)
+        public async Task<IActionResult> Registration(RegistrateDto request)
         {
             // Call registration service
             await _authService.Registration(request);
@@ -40,7 +40,7 @@ namespace PalatePilot.Server.Controllers
 
         // POST: api/Auth/Login
         [HttpPost("Login")]
-        public async Task<IActionResult> Login(LoginRequestDto request)
+        public async Task<IActionResult> Login(LoginDto request)
         {
             // Call login service
             string jwtToken = await _authService.Login(request);

--- a/Apps/PalatePilot.Server/Controllers/EmailController.cs
+++ b/Apps/PalatePilot.Server/Controllers/EmailController.cs
@@ -24,7 +24,7 @@ namespace PalatePilot.Server.Controllers
         [HttpPost]
         [Route("SendEmail")]
         
-        public async Task<IActionResult> SendEmail(EmailRequestDto request)
+        public async Task<IActionResult> SendEmail(EmailDto request)
         {
             await _emailService.SendEmailAsync(request);
 

--- a/Apps/PalatePilot.Server/Models/Dto/EmailDto.cs
+++ b/Apps/PalatePilot.Server/Models/Dto/EmailDto.cs
@@ -1,7 +1,7 @@
 using System;
 namespace PalatePilot.Server.Models.Dto
 {
-    public class EmailRequestDto
+    public class EmailDto
     {
         public string Email { get; set; } = string.Empty;
         public string Username { get; set; } = string.Empty;

--- a/Apps/PalatePilot.Server/Models/Dto/LoginDto.cs
+++ b/Apps/PalatePilot.Server/Models/Dto/LoginDto.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace PalatePilot.Server.Models
 {
-    public class LoginRequestDto
+    public class LoginDto
     {
         [Required]
         public string UserName { get; set; } = string.Empty;

--- a/Apps/PalatePilot.Server/Models/Dto/RegistrationDto.cs
+++ b/Apps/PalatePilot.Server/Models/Dto/RegistrationDto.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace PalatePilot.Server.Models
 {
-    public class RegistrationRequestDto
+    public class RegistrateDto
     {
         [Required]
         public string UserName { get; set; } = string.Empty;

--- a/Apps/PalatePilot.Server/Services/AuthService/AuthService.cs
+++ b/Apps/PalatePilot.Server/Services/AuthService/AuthService.cs
@@ -25,7 +25,7 @@ namespace PalatePilot.Server.Services
             _config = config;
         }
 
-        public async Task Registration(RegistrationRequestDto request)
+        public async Task Registration(RegistrateDto request)
         {
            var newUser = new IdentityUser
            {
@@ -56,7 +56,7 @@ namespace PalatePilot.Server.Services
                 }
             );
 
-            var emailRequest = new EmailRequestDto
+            var emailRequest = new EmailDto
             {
                 Email = request.Email,
                 Username = request.UserName,
@@ -67,7 +67,7 @@ namespace PalatePilot.Server.Services
             await _emailService.SendEmailAsync(emailRequest);
         }
 
-        public async Task<string> Login(LoginRequestDto request)
+        public async Task<string> Login(LoginDto request)
         {
             var fetchedUser = await _userManger.FindByNameAsync(request.UserName);
             if(fetchedUser == null || !await _userManger.CheckPasswordAsync(fetchedUser, request.Password))
@@ -95,7 +95,7 @@ namespace PalatePilot.Server.Services
             var confirmResult = await _userManger.ConfirmEmailAsync(fetchedUser, token);
             if(!confirmResult.Succeeded)
             {
-                throw new BadRequestException("Invalid Email Confirmation Request");
+                throw new BadRequestException("Email Confirmation operation failed.");
             }
         }
 
@@ -120,7 +120,7 @@ namespace PalatePilot.Server.Services
                 }
             );
 
-            var emailRequest = new EmailRequestDto
+            var emailRequest = new EmailDto
             {
                 Email = fetchedUser.Email,
                 Username = fetchedUser.UserName,

--- a/Apps/PalatePilot.Server/Services/AuthService/IAuthService.cs
+++ b/Apps/PalatePilot.Server/Services/AuthService/IAuthService.cs
@@ -10,8 +10,8 @@ namespace PalatePilot.Server.Services
 {
     public interface IAuthService
     {
-        Task Registration(RegistrationRequestDto request);
-        Task<string> Login(LoginRequestDto request);
+        Task Registration(RegistrateDto request);
+        Task<string> Login(LoginDto request);
         Task EmailConfirmation(string token, string email);
         Task ForgotPassword(ForgotPasswordDto forgotPasswordDto);
         Task ResetPassword(ResetPasswordDto resetPasswordDto);

--- a/Apps/PalatePilot.Server/Services/EmailService/EmailService.cs
+++ b/Apps/PalatePilot.Server/Services/EmailService/EmailService.cs
@@ -14,7 +14,7 @@ namespace PalatePilot.Server.Services.EmailService
             _emailConfig = emailConfigOptions.Value;
         }
 
-        public async Task SendEmailAsync(EmailRequestDto request)
+        public async Task SendEmailAsync(EmailDto request)
         {
             var emailMessage = CreateEmailMessage(request);
             await SendAsync(emailMessage);
@@ -38,7 +38,7 @@ namespace PalatePilot.Server.Services.EmailService
             }
         }
 
-        private MimeMessage CreateEmailMessage(EmailRequestDto request)
+        private MimeMessage CreateEmailMessage(EmailDto request)
         {
             // Initialize the email message
             var emailMessage = new MimeMessage();

--- a/Apps/PalatePilot.Server/Services/EmailService/IEmailService.cs
+++ b/Apps/PalatePilot.Server/Services/EmailService/IEmailService.cs
@@ -5,6 +5,6 @@ namespace PalatePilot.Server.Services.EmailService
 {
     public interface IEmailService
     {
-        Task SendEmailAsync(EmailRequestDto request);
+        Task SendEmailAsync(EmailDto request);
     }
 }


### PR DESCRIPTION
What has changed:
- Rename dtos: EmailDto, LoginDto, RegistrationDto

Reason for changes:
- Make them shorter and easier to read
- Consistent code so all dto follow the same name convension