### PR TITLE
rename RegistrateDto

### DIFF
--- a/Apps/PalatePilot.Server/Controllers/AuthController.cs
+++ b/Apps/PalatePilot.Server/Controllers/AuthController.cs
@@ -21,7 +21,7 @@ namespace PalatePilot.Server.Controllers
         // POST: api/Auth/Registration
         [HttpPost("Registration")]
         [ValidateModel]
-        public async Task<IActionResult> Registration(RegistrateDto request)
+        public async Task<IActionResult> Registration(RegistrationDto request)
         {
             // Call registration service
             await _authService.Registration(request);

--- a/Apps/PalatePilot.Server/Models/Dto/RegistrationDto.cs
+++ b/Apps/PalatePilot.Server/Models/Dto/RegistrationDto.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace PalatePilot.Server.Models
 {
-    public class RegistrateDto
+    public class RegistrationDto
     {
         [Required]
         public string UserName { get; set; } = string.Empty;

--- a/Apps/PalatePilot.Server/Services/AuthService/AuthService.cs
+++ b/Apps/PalatePilot.Server/Services/AuthService/AuthService.cs
@@ -25,7 +25,7 @@ namespace PalatePilot.Server.Services
             _config = config;
         }
 
-        public async Task Registration(RegistrateDto request)
+        public async Task Registration(RegistrationDto request)
         {
            var newUser = new IdentityUser
            {

--- a/Apps/PalatePilot.Server/Services/AuthService/IAuthService.cs
+++ b/Apps/PalatePilot.Server/Services/AuthService/IAuthService.cs
@@ -10,7 +10,7 @@ namespace PalatePilot.Server.Services
 {
     public interface IAuthService
     {
-        Task Registration(RegistrateDto request);
+        Task Registration(RegistrationDto request);
         Task<string> Login(LoginDto request);
         Task EmailConfirmation(string token, string email);
         Task ForgotPassword(ForgotPasswordDto forgotPasswordDto);


### PR DESCRIPTION
What has changed:
- Rename RegistrateDto to RegistrationDto

Reason for changes:
- the commit before this dto has been rename
- it didn't create any benefits for the application