### PR TITLE
Configure SwaggerGen with JWT authentication

### DIFF
--- a/Apps/PalatePilot.Server/Program.cs
+++ b/Apps/PalatePilot.Server/Program.cs
@@ -12,6 +12,7 @@ using PalatePilot.Server.Services;
 using PalatePilot.Server.Services.EmailService;
 using PalatePilot.Server.Services.FoodService;
 using Serilog;
+using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -19,7 +20,36 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddJsonFile("secret.json", optional: false, reloadOnChange: false);
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(options => 
+{
+    options.SwaggerDoc("v1", new OpenApiInfo { Title = "Food API", Version = "v1"});
+    options.AddSecurityDefinition(JwtBearerDefaults.AuthenticationScheme, new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = JwtBearerDefaults.AuthenticationScheme
+    });
+
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+            
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = JwtBearerDefaults.AuthenticationScheme
+                },
+                Scheme = "Oauth2",
+                Name = JwtBearerDefaults.AuthenticationScheme,
+                In = ParameterLocation.Header
+            },
+            new List<string>()
+        }
+    });
+});
 
 // Custom registration of services
 builder.Services.AddTransient<IAuthService, AuthService>();


### PR DESCRIPTION
What has changed:
- Added SwaggerGen configuration to document the Food API with Swagger
- Defined a security definition for JWT bearer authentication with the header parameter "Authorization"
- Specified a security requirement to enforce JWT authentication for all API endpoints

Reason for changes:
- Setting up Swagger documentation for the Food API and defining security requirements to document JWT authentication for accessing the API endpoints