### PR TITLE
Enable persistence of authorization in Swagger UI

### DIFF
--- a/Apps/PalatePilot.Server/Program.cs
+++ b/Apps/PalatePilot.Server/Program.cs
@@ -148,7 +148,10 @@ app.UseStaticFiles();
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
-    app.UseSwaggerUI();
+    app.UseSwaggerUI(options => 
+    {
+        options.ConfigObject.AdditionalItems.Add("persistAuthorization", "true");
+    });
     app.UseCors(builder => builder.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin());
 }
 


### PR DESCRIPTION
What has changed:
- Added configuration to enable the persistence of authorization in Swagger UI.

Reason for changes:
- To ensure that authorization settings are persisted which will make it easier to test restricted resources